### PR TITLE
chore(renovate): adopt shared presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,26 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "enabledManagers": ["github-actions"],
+  "extends": ["local>xlionjuan/renovatebot-presets"],
   "packageRules": [
     {
+      "description": "This repository has no PR CI. Automerge only minor and patch updates of actions/checkout without tests.",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["pin", "digest", "pinDigest","major", "minor", "patch"],
-      "labels": ["dependencies"]
-    },
-    {
       "matchPackageNames": ["actions/checkout"],
       "matchUpdateTypes": ["minor", "patch"],
       "ignoreTests": true,
-      "automerge": true,
-      "labels": ["dependencies"]
+      "automerge": true
     },
     {
+      "description": "This repository has no PR CI. Automerge only minor and patch updates of actions/attest without tests.",
+      "matchManagers": ["github-actions"],
       "matchPackageNames": ["actions/attest"],
       "matchUpdateTypes": ["minor", "patch"],
       "ignoreTests": true,
-      "automerge": true,
-      "labels": ["dependencies"]
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- adopt `local>xlionjuan/renovatebot-presets`
- retain narrowly scoped no-CI automerge for minor and patch updates of `actions/checkout` and `actions/attest`
- leave major, pin, and digest updates subject to the shared manual/CI policy

## Validation

- `renovate-config-validator --strict --no-global .github/renovate.json`
- `git diff --check`
- pushed through the special `renovate/reconfigure` validation branch
